### PR TITLE
Migrate CI service from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [7.1, 7.2, 7.3, 7.4]
+        lib:
+          - { laravel: ^8.0, testbench: ^6.0, composer_flags: --prefer-stable }
+          - { laravel: ^7.0, testbench: ^5.0, composer_flags: --prefer-stable }
+          - { laravel: ^6.0, testbench: ^4.0, composer_flags: --prefer-stable }
+          - { laravel: ^6.0, testbench: ^4.0, composer_flags: --prefer-stable --prefer-lowest }
+          - { laravel: 5.8.*, testbench: 3.8.*, composer_flags: --prefer-stable }
+          - { laravel: 5.7.*, testbench: 3.7.*, composer_flags: --prefer-stable }
+          - { laravel: 5.6.*, testbench: 3.6.*, composer_flags: --prefer-stable }
+        exclude:
+          - lib: { laravel: ^8.0, testbench: ^6.0, composer_flags: --prefer-stable }
+            php: 7.2
+          - lib: { laravel: ^8.0, testbench: ^6.0, composer_flags: --prefer-stable }
+            php: 7.1
+          - lib: { laravel: ^7.0, testbench: ^5.0, composer_flags: --prefer-stable }
+            php: 7.1
+          - lib: { laravel: ^6.0, testbench: ^4.0, composer_flags: --prefer-stable }
+            php: 7.1
+          - lib: { laravel: ^6.0, testbench: ^4.0, composer_flags: --prefer-stable --prefer-lowest }
+            php: 7.1
+
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+
+      - run: composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
+      - run: composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update
+      - run: composer update
+      - run: mkdir -p build/logs
+      - run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Upload Coverage
+        uses: nick-invision/retry@v2
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          timeout_minutes: 1
+          max_attempts: 3
+          command: |
+            composer global require php-coveralls/php-coveralls
+            php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
         lib:
           - { laravel: ^8.0, testbench: ^6.0, composer_flags: --prefer-stable }
           - { laravel: ^7.0, testbench: ^5.0, composer_flags: --prefer-stable }
@@ -28,6 +28,12 @@ jobs:
             php: 7.1
           - lib: { laravel: ^6.0, testbench: ^4.0, composer_flags: --prefer-stable --prefer-lowest }
             php: 7.1
+          - lib: { laravel: 5.8.*, testbench: 3.8.*, composer_flags: --prefer-stable }
+            php: 8.0
+          - lib: { laravel: 5.7.*, testbench: 3.7.*, composer_flags: --prefer-stable }
+            php: 8.0
+          - lib: { laravel: 5.6.*, testbench: 3.6.*, composer_flags: --prefer-stable }
+            php: 8.0
 
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
-            composer require "orchestra/testbench:>=4.13" --dev --no-update ${{ matrix.lib.composer_flags }}
+            composer require "orchestra/testbench:>=4.14" --dev --no-update ${{ matrix.lib.composer_flags }}
             composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
-            composer require "orchestra/testbench:>=4.9" --dev --no-update ${{ matrix.lib.composer_flags }}
+            composer require "orchestra/testbench:>=4.13" --dev --no-update ${{ matrix.lib.composer_flags }}
             composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,14 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
 
-      - run: composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
-      - run: composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update
-      - run: composer update
+      - name: Adjust package versions
+        run: |
+          composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
+          composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}
+          if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
+            composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
+          fi
+          composer update ${{ matrix.lib.composer_flags }}
       - run: mkdir -p build/logs
       - run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
-            composer require "orchestra/testbench:4.7.2" --dev --no-update ${{ matrix.lib.composer_flags }}
+            composer require "orchestra/testbench:v4.7.2" --dev --no-update ${{ matrix.lib.composer_flags }}
             composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
             composer require "orchestra/testbench:>=4.14" --dev --no-update ${{ matrix.lib.composer_flags }}
-            composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
-            composer require "orchestra/testbench:v4.7.2" --dev --no-update ${{ matrix.lib.composer_flags }}
+            composer require "orchestra/testbench:>=4.9" --dev --no-update ${{ matrix.lib.composer_flags }}
             composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
             composer require "orchestra/testbench:>=4.14" --dev --no-update ${{ matrix.lib.composer_flags }}
+            composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
           else
             composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Adjust package versions
         run: |
           composer require "laravel/framework:${{ matrix.lib.laravel }}" --dev --no-update ${{ matrix.lib.composer_flags }}
-          composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           if php -r 'exit((int)!version_compare(PHP_VERSION, "8", ">="));'; then
+            composer require "orchestra/testbench:4.7.2" --dev --no-update ${{ matrix.lib.composer_flags }}
             composer require "phpunit/phpunit:>=9.3" --dev --no-update ${{ matrix.lib.composer_flags }}
+          else
+            composer require "orchestra/testbench:${{ matrix.lib.testbench }}" --dev --no-update ${{ matrix.lib.composer_flags }}
           fi
           composer update ${{ matrix.lib.composer_flags }}
       - run: mkdir -p build/logs

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Laravel Database Mock [![Build Status](https://travis-ci.com/mpyw/laravel-database-mock.svg?branch=master)](https://travis-ci.com/mpyw/laravel-database-mock) [![Coverage Status](https://coveralls.io/repos/github/mpyw/laravel-database-mock/badge.svg?branch=master)](https://coveralls.io/github/mpyw/laravel-database-mock?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mpyw/laravel-database-mock/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mpyw/laravel-database-mock/?branch=master)
+# Laravel Database Mock [![Build Status](https://github.com/mpyw/laravel-database-mock/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mpyw/laravel-database-mock/actions) [![Coverage Status](https://coveralls.io/repos/github/mpyw/laravel-database-mock/badge.svg?branch=master)](https://coveralls.io/github/mpyw/laravel-database-mock?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mpyw/laravel-database-mock/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mpyw/laravel-database-mock/?branch=master)
 
 **[Experimental]** Database Mocking Library which mocks `PDO` underlying Laravel Connection classes.
 
 ## Requirements
 
-- PHP: ^7.1
-- Laravel: ^5.6 || ^6.0 || ^7.0 || ^8.0
-- Mockery: ^1.0
-- [mpyw/mockery-pdo](https://github.com/mpyw/mockery-pdo): alpha
+- PHP: `^7.1`
+- Laravel: `^5.6 || ^6.0 || ^7.0 || ^8.0`
+- Mockery: `^1.0`
+- [mpyw/mockery-pdo](https://github.com/mpyw/mockery-pdo): `alpha`
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- PHP: `^7.1`
+- PHP: `^7.1 || ^8.0`
 - Laravel: `^5.6 || ^6.0 || ^7.0 || ^8.0`
 - Mockery: `^1.0`
 - [mpyw/mockery-pdo](https://github.com/mpyw/mockery-pdo): `alpha`

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-pdo": "*",
         "illuminate/database": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/support": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "mpyw/mockery-pdo": "0.0.1-alpha5@alpha"
+        "mpyw/mockery-pdo": "0.0.1-alpha6@alpha"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "require-dev": {
         "orchestra/testbench": "^6.0",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "php-coveralls/php-coveralls": "^2.1",
         "nilportugues/sql-query-formatter": "^1.2",
         "awobaz/compoships": "^2.0"
     },


### PR DESCRIPTION
This contains upgrading `mpyw/mockery-pdo` to `0.0.1-alpha6` for supporting PHP 8.